### PR TITLE
include unistd.h in notetaker.c and notesearch.c

### DIFF
--- a/booksrc/notesearch.c
+++ b/booksrc/notesearch.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include "hacking.h"
 

--- a/booksrc/notetaker.c
+++ b/booksrc/notetaker.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include "hacking.h"
 


### PR DESCRIPTION
this prevents a warning when compiling and also made notesearch work for me (it didn't before)